### PR TITLE
Update docs on how to add redirect URI to Spotify

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ To use this plugin, you have to provide a client id, a client secret,
 and a personal refresh token from Spotify. To do this, first
 [create a new Spotify App](https://developer.spotify.com/dashboard/applications).
 
+After you create it, click the "Edit Settings" button on the application dashboard and add `http://localhost:5071/spotify` to the "Redirect URIs" section and hit save.
+
 You can then run gatsby-source-spotify's integrated tool to log in using your
 Spotify account and to get your refresh token.
 


### PR DESCRIPTION
Fixes #1 

In order for the command line application that generates the API token to work, `http://localhost:5071/spotify` needs to be added as a valid redirect URL for the Spotify application.  This PR adds instructions for how to do that.  This is a required step in order to properly generate the token used to communicate with the Spotify API.